### PR TITLE
Feat: move SSH op to separate threads for non-blocking UI

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -68,6 +68,7 @@ enum Task {
 
 /// Represents the result of executing a Task.
 /// The UI thread will receive these results and update the UI state accordingly.
+#[allow(clippy::enum_variant_names)]
 enum TaskResult {
     /// The result of the connect attempt
     ConnectResult(Result<(), String>),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -133,7 +133,7 @@ impl BackgroundWorker {
 
                     Task::ListDirectory(path) => {
                         if let Some(conn) = connection.as_ref() {
-                            let result = conn.list_directory(&path).map_err(|e| e);
+                            let result = conn.list_directory(&path);
                             let _ = result_sender.send(TaskResult::ListDirectoryResult(result));
                         } else {
                             let _ = result_sender


### PR DESCRIPTION
This PR relate blocking part from https://github.com/0xb-s/ssh-browser/issues/18

This PR moves SSH operations to backgroud worker thread. From this, we can make the egui responsive while running SSH operations